### PR TITLE
Fix Access-Control-Allow-Origin

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,8 @@
         return 0;
       }
       var instance = axios.create({
-        baseURL: 'http://149.56.64.85/api'
+        baseURL: 'http://149.56.64.85/api',
+	headers: {"Access-Control-Allow-Origin": "*"}
       })
       instance.get('/startups')
         .then(function (res) {


### PR DESCRIPTION
Added `Access-Control-Allow-Origin` header field to prevent this error : 

`Failed to load http://149.56.64.85/api/startups: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://nakamology.ir' is therefore not allowed access.`