### PR TITLE
Revert "Fix Access-Control-Allow-Origin"

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,8 +203,7 @@
         return 0;
       }
       var instance = axios.create({
-        baseURL: 'http://149.56.64.85/api',
-	headers: {"Access-Control-Allow-Origin": "*"}
+        baseURL: 'http://149.56.64.85/api'
       })
       instance.get('/startups')
         .then(function (res) {


### PR DESCRIPTION
Reverts IKAcc/nakamology#1

Merging this PR created new error: `Failed to load http://149.56.64.85/api/startups: Request header field Access-Control-Allow-Origin is not allowed by Access-Control-Allow-Headers in preflight response.`

Will work on it other time.